### PR TITLE
fix: npm ci to install dps

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -25,10 +25,10 @@ jobs:
                   node-version: ${{ matrix.node_version }}
             - name: Docker run containers and tests
               env:
-                GRAPHHOPPER_API_KEY: ${{ secrets.GRAPHHOPPER_API_KEY }}
+                  GRAPHHOPPER_API_KEY: ${{ secrets.GRAPHHOPPER_API_KEY }}
               run: |
                   docker compose up -d
                   sleep 10
-                  npm install
+                  npm ci
                   npm test
                   docker compose down

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,9 +20,9 @@ jobs:
                   node-version: "16.x"
             - name: Build Docusaurus website
               run: |
-                  npm install
+                  npm ci
                   cd docs
-                  npm install
+                  npm ci
                   npm run build
             - name: Deploy to GitHub Pages
               if: success()


### PR DESCRIPTION
Using `npm ci` to install dependencies during github action workflows.