### PR TITLE
fix: call to _buildLocations when setting exclude_locations

### DIFF
--- a/packages/valhalla/index.ts
+++ b/packages/valhalla/index.ts
@@ -337,7 +337,7 @@ export class Valhalla implements BaseRouter {
                     ])
                 }
             })
-            params.exclude_locations = avoidLocations
+            params.exclude_locations = this._buildLocations(avoidLocations);
         }
 
         if (directionsOpts.avoidPolygons) {

--- a/packages/valhalla/parameters.ts
+++ b/packages/valhalla/parameters.ts
@@ -94,7 +94,7 @@ interface ValhallaRequestParams {
      * minimum each avoid location must include latitude and longitude. The avoid_locations are
      * mapped to the closest road or roads and these roads are excluded from the route path computation.
      */
-    exclude_locations?: [number, number][]
+    exclude_locations?: [number, number][] | ValhallaLocation[]
     /**
      * One or multiple exterior rings of polygons in the form of nested JSON arrays, e.g.
      * [[[lon1, lat1], [lon2,lat2]],[[lon1,lat1],[lon2,lat2]]]. Roads intersecting these rings

--- a/packages/valhalla/valhalla.test.ts
+++ b/packages/valhalla/valhalla.test.ts
@@ -32,6 +32,26 @@ describe("Valhalla returns responses", () => {
             })
     })
 
+    it("gets a directions response when passing exclude_locations", async () => {
+        await v
+            .directions(
+                [
+                    [-33.3844596, 148.0080975],
+                    [-33.8346839, 148.6911799],
+                ],
+                "auto",
+                {
+                    avoidLocations: [[-33.4023733, 148.0193885]],
+                }
+            )
+            .then((d) => {
+                expect(d.raw).toBeDefined()
+                expect(d.raw?.trip?.status_message).toBe(
+                    "Found route between points"
+                )
+            })
+    })
+
     it("gets an isochrone response", async () => {
         await v
             .reachability([42.50823, 1.52601], "pedestrian", [30, 90])


### PR DESCRIPTION
re: Issue #31

- Added call to _buildLocations when settings exclude_locations in direction request options.
- Added alternative type of ValhallaLocation[] to exclude_locations definition
- Created test

No changes made to isochrone request options.