### PR TITLE
Expose parse* methods as static methods; typings were off for trace_route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+**Unreleased** is available in Github's `main` branch, but not on npm.
+
+## **Unreleased**
+
+### Added
+
+-   Expose parse\* methods as static methods for Valhalla ([#35](https://github.com/gis-ops/routingjs/pull/35))
+-   This Changelog ;-) ([#35](https://github.com/gis-ops/routingjs/pull/35))
+
+### Fixed
+
+-   Remove `directionsOpts` as top level options in `ValhallaTraceRouteOpts` ([#35](https://github.com/gis-ops/routingjs/pull/35))

--- a/packages/valhalla/index.ts
+++ b/packages/valhalla/index.ts
@@ -199,7 +199,6 @@ export interface ValhallaMatrixOpts extends ValhallaBaseOpts {
     units?: ValhallaRequestUnit
 }
 
-// export interface ValhallaAdditionalTraceOpts
 export interface ValhallaTraceRouteOpts
     extends Omit<ValhallaBaseOpts, "avoidLocations" | "avoidPolygons"> {
     /**
@@ -339,7 +338,7 @@ export class Valhalla implements BaseRouter {
         const getParams: MapboxAuthParams | undefined = this.apiKey
             ? { access_token: this.apiKey }
             : undefined
-        const params = this.getDirectionParams(
+        const params = Valhalla.getDirectionParams(
             locations,
             profile,
             directionsOpts
@@ -365,13 +364,13 @@ export class Valhalla implements BaseRouter {
             .catch(handleValhallaError)
     }
 
-    protected getDirectionParams(
+    public static getDirectionParams(
         locations: [number, number][],
         profile: ValhallaCostingType,
         directionsOpts: ValhallaDirectionOpts = {}
     ): ValhallaRouteParams {
         const params: ValhallaRouteParams = {
-            locations: this._buildLocations(locations),
+            locations: Valhalla._buildLocations(locations),
             costing: profile,
             narrative: directionsOpts.instructions || false,
         }
@@ -561,7 +560,7 @@ export class Valhalla implements BaseRouter {
         const getParams: MapboxAuthParams | undefined = this.apiKey
             ? { access_token: this.apiKey }
             : undefined
-        const params = this.getIsochroneParams(
+        const params = Valhalla.getIsochroneParams(
             location,
             profile,
             intervals,
@@ -592,7 +591,7 @@ export class Valhalla implements BaseRouter {
             .catch(handleValhallaError)
     }
 
-    public getIsochroneParams(
+    public static getIsochroneParams(
         location: [number, number],
         profile: ValhallaCostingType,
         intervals: number[],
@@ -623,7 +622,7 @@ export class Valhalla implements BaseRouter {
         })
 
         const params: ValhallaIsochroneParams = {
-            locations: this._buildLocations(location),
+            locations: Valhalla._buildLocations(location),
             costing: profile,
             contours,
             polygons: isochroneOpts.polygons,
@@ -753,7 +752,7 @@ export class Valhalla implements BaseRouter {
         const getParams: MapboxAuthParams | undefined = this.apiKey
             ? { access_token: this.apiKey }
             : undefined
-        const params = this.getMatrixParams(locations, profile, matrixOpts)
+        const params = Valhalla.getMatrixParams(locations, profile, matrixOpts)
 
         return this.client
             .request({
@@ -775,12 +774,12 @@ export class Valhalla implements BaseRouter {
             .catch(handleValhallaError)
     }
 
-    public getMatrixParams(
+    public static getMatrixParams(
         locations: [number, number][],
         profile: ValhallaCostingType,
         matrixOpts: ValhallaMatrixOpts = {}
     ): ValhallaMatrixParams {
-        const matrixLocations = this._buildLocations(locations)
+        const matrixLocations = Valhalla._buildLocations(locations)
 
         let sourceCoords = matrixLocations
 
@@ -917,7 +916,7 @@ export class Valhalla implements BaseRouter {
         const getParams: MapboxAuthParams | undefined = this.apiKey
             ? { access_token: this.apiKey }
             : undefined
-        const params = this.getTraceRouteParams(
+        const params = Valhalla.getTraceRouteParams(
             locations,
             profile,
             traceRouteOpts
@@ -943,7 +942,7 @@ export class Valhalla implements BaseRouter {
             .catch(handleValhallaError)
     }
 
-    protected getTraceRouteParams(
+    public static getTraceRouteParams(
         locations: [number, number][],
         profile: ValhallaCostingType,
         traceRouteOpts: ValhallaTraceRouteOpts = {}
@@ -990,11 +989,13 @@ export class Valhalla implements BaseRouter {
         return params
     }
 
-    protected _buildLocations(
+    public static _buildLocations(
         coordinates: [number, number][]
     ): ValhallaLocation[]
-    protected _buildLocations(coordinates: [number, number]): [ValhallaLocation]
-    protected _buildLocations(
+    public static _buildLocations(
+        coordinates: [number, number]
+    ): [ValhallaLocation]
+    public static _buildLocations(
         coordinates: [number, number][] | [number, number]
     ): ValhallaLocation[] {
         if (Array.isArray(coordinates[0])) {

--- a/packages/valhalla/index.ts
+++ b/packages/valhalla/index.ts
@@ -201,8 +201,7 @@ export interface ValhallaMatrixOpts extends ValhallaBaseOpts {
 
 // export interface ValhallaAdditionalTraceOpts
 export interface ValhallaTraceRouteOpts
-    extends Omit<ValhallaBaseOpts, "exclude_locations" | "exclude_polygons">,
-        ValhallaDirectionOpts {
+    extends Omit<ValhallaBaseOpts, "avoidLocations" | "avoidPolygons"> {
     /**
      * shape_match is an optional string input parameter. It allows some control
      * of the matching algorithm based on the type of input.
@@ -981,9 +980,9 @@ export class Valhalla implements BaseRouter {
         }
 
         params.directions_options = {
-            language: traceRouteOpts.language,
-            units: traceRouteOpts.units,
-            directions_type: traceRouteOpts.directionsType,
+            language: traceRouteOpts.directionsOptions?.language,
+            units: traceRouteOpts.directionsOptions?.units,
+            directions_type: traceRouteOpts.directionsOptions?.directionsType,
         }
 
         params.id = traceRouteOpts.id

--- a/packages/valhalla/valhalla.test.ts
+++ b/packages/valhalla/valhalla.test.ts
@@ -83,7 +83,6 @@ describe("Valhalla returns responses", () => {
                 "pedestrian"
             )
             .then((d) => {
-                console.log(JSON.stringify(d.raw))
                 expect(d.raw).toBeDefined()
                 expect(d.directions).toHaveLength(1)
                 expect(d.directions[0]).toHaveProperty("feature")


### PR DESCRIPTION
Quite a bit of stuff all in one PR but I figured it's ok for now, not really a lot of attention given to this library :smile: 